### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "tap --reporter=tap test/runner.js"
   },
-  "repository" : {
+  "repository": {
     "type": "git",
     "url": "git://github.com/AndreasMadsen/interpreted.git"
   },
@@ -18,9 +18,9 @@
     "transform"
   ],
   "dependencies": {
-    "tap": "^6.3.2",
-    "async": "^2.0.1",
-    "util-extend": "^1.0.1"
+    "tap": "^12.0.1",
+    "async": "^2.6.1",
+    "util-extend": "^1.0.3"
   },
   "devDependencies": {
     "endpoint": "0.4.x"


### PR DESCRIPTION
Old version with `npm audit`:

```
found 29 vulnerabilities (19 low, 10 moderate) in 851 scanned packages
  29 vulnerabilities require semver-major dependency updates.
```

Updated version:

```
found 0 vulnerabilities
 in 2408 scanned packages
```

Note: I'm not sure about the meaning of the `test/fixture/*.txt` files which are updated on `npm test`. Maybe it would be best to add them to the `.gitignore`.