### PR TITLE
Update devDep tap@14; Use --no-coverage for tap calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Andreas Madsen <amwebdk@gmail.com>",
   "main": "./interpreted.js",
   "scripts": {
-    "test": "tap --reporter=tap test/runner.js"
+    "test": "tap --reporter=tap --no-coverage test/runner.js"
   },
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
     "transform"
   ],
   "dependencies": {
-    "tap": "^12.0.1",
+    "tap": "^14.8.2",
     "async": "^2.6.1",
     "util-extend": "^1.0.3"
   },

--- a/test/runner.js
+++ b/test/runner.js
@@ -23,7 +23,7 @@ function runTest(name, callback) {
   };
 
   return function (t) {
-    var cp = spawn(tapPath, ['--reporter=tap', path.resolve(__dirname, name, 'runner.js')], {
+    var cp = spawn(tapPath, ['--reporter=tap', '--no-coverage', path.resolve(__dirname, name, 'runner.js')], {
       cwd: path.resolve(__dirname, name)
     });
 


### PR DESCRIPTION
tap@12 has a transitive dependency on diff@ <3.5.0, which has a vulnerability found by npm audit and GitHub Alerts.

I also added `--no-coverage` option for all tap runners, as coverage reports are enabled by default since tap@13.