### PR TITLE
Remove timings in test/fixture

### DIFF
--- a/test/fixture/all-good.txt
+++ b/test/fixture/all-good.txt
@@ -1,13 +1,11 @@
 TAP version 13
-ok 1 - /interpreted/test/all-good/runner.js # time=25.936ms {
+ok 1 - /interpreted/test/all-good/runner.js {
     # Subtest: test stringify interpreted
         ok 1 - should be equivalent
         1..1
-    ok 1 - test stringify interpreted # time=14.195ms
+    ok 1 - test stringify interpreted
     
     1..1
-    # time=25.936ms
 }
 
 1..1
-# time=688.293ms

--- a/test/fixture/close-bad.txt
+++ b/test/fixture/close-bad.txt
@@ -1,5 +1,5 @@
 TAP version 13
-not ok 1 - /interpreted/test/close-bad/runner.js # time=48.389ms
+not ok 1 - /interpreted/test/close-bad/runner.js
   ---
   env: {}
   file: /interpreted/test/close-bad/runner.js
@@ -26,13 +26,11 @@ not ok 1 - /interpreted/test/close-bad/runner.js # time=48.389ms
         
         1..1
         # failed 1 test
-    not ok 1 - close interperted tester # time=26.818ms
+    not ok 1 - close interperted tester
     
     1..1
     # failed 1 test
-    # time=48.389ms
 }
 
 1..1
 # failed 1 test
-# time=563.279ms

--- a/test/fixture/expected-missing.txt
+++ b/test/fixture/expected-missing.txt
@@ -1,5 +1,5 @@
 TAP version 13
-not ok 1 - /interpreted/test/expected-missing/runner.js # time=420.434ms
+not ok 1 - /interpreted/test/expected-missing/runner.js
   ---
   env: {}
   file: /interpreted/test/expected-missing/runner.js
@@ -22,4 +22,3 @@ not ok 1 - /interpreted/test/expected-missing/runner.js # time=420.434ms
 
 1..1
 # failed 1 test
-# time=466.947ms

--- a/test/fixture/file-ext.txt
+++ b/test/fixture/file-ext.txt
@@ -1,23 +1,21 @@
 TAP version 13
-ok 1 - /interpreted/test/file-ext/runner.js # time=43.035ms {
+ok 1 - /interpreted/test/file-ext/runner.js {
     # Subtest: test default interpreted
         ok 1 - should be equal
         1..1
-    ok 1 - test default interpreted # time=16.978ms
+    ok 1 - test default interpreted
     
     # Subtest: test special interpreted
         ok 1 - should be equivalent
         1..1
-    ok 2 - test special interpreted # time=10.479ms
+    ok 2 - test special interpreted
     
     # Subtest: test stringify interpreted
         ok 1 - should be equivalent
         1..1
-    ok 3 - test stringify interpreted # time=6.408ms
+    ok 3 - test stringify interpreted
     
     1..3
-    # time=43.035ms
 }
 
 1..1
-# time=534.209ms

--- a/test/fixture/no-source-read.txt
+++ b/test/fixture/no-source-read.txt
@@ -1,13 +1,11 @@
 TAP version 13
-ok 1 - /interpreted/test/no-source-read/runner.js # time=36.569ms {
+ok 1 - /interpreted/test/no-source-read/runner.js {
     # Subtest: test stringify interpreted
         ok 1 - should be equivalent
         1..1
-    ok 1 - test stringify interpreted # time=26.616ms
+    ok 1 - test stringify interpreted
     
     1..1
-    # time=36.569ms
 }
 
 1..1
-# time=536.181ms

--- a/test/fixture/run-only.txt
+++ b/test/fixture/run-only.txt
@@ -1,13 +1,11 @@
 TAP version 13
-ok 1 - /interpreted/test/run-only/runner.js # time=33.842ms {
+ok 1 - /interpreted/test/run-only/runner.js {
     # Subtest: test only interpreted
         ok 1 - should be equivalent
         1..1
-    ok 1 - test only interpreted # time=19.668ms
+    ok 1 - test only interpreted
     
     1..1
-    # time=33.842ms
 }
 
 1..1
-# time=533.691ms

--- a/test/fixture/source-missing.txt
+++ b/test/fixture/source-missing.txt
@@ -1,5 +1,5 @@
 TAP version 13
-not ok 1 - /interpreted/test/source-missing/runner.js # time=421.074ms
+not ok 1 - /interpreted/test/source-missing/runner.js
   ---
   env: {}
   file: /interpreted/test/source-missing/runner.js
@@ -22,4 +22,3 @@ not ok 1 - /interpreted/test/source-missing/runner.js # time=421.074ms
 
 1..1
 # failed 1 test
-# time=467.22ms

--- a/test/fixture/start-bad.txt
+++ b/test/fixture/start-bad.txt
@@ -1,5 +1,5 @@
 TAP version 13
-not ok 1 - /interpreted/test/start-bad/runner.js # time=64.251ms
+not ok 1 - /interpreted/test/start-bad/runner.js
   ---
   env: {}
   file: /interpreted/test/start-bad/runner.js
@@ -26,13 +26,11 @@ not ok 1 - /interpreted/test/start-bad/runner.js # time=64.251ms
         
         1..1
         # failed 1 test
-    not ok 1 - start interpreted tester # time=34.788ms
+    not ok 1 - start interpreted tester
     
     1..1
     # failed 1 test
-    # time=64.251ms
 }
 
 1..1
 # failed 1 test
-# time=736.852ms

--- a/test/fixture/test-bad.txt
+++ b/test/fixture/test-bad.txt
@@ -1,5 +1,5 @@
 TAP version 13
-not ok 1 - /interpreted/test/test-bad/runner.js # time=39.195ms
+not ok 1 - /interpreted/test/test-bad/runner.js
   ---
   env: {}
   file: /interpreted/test/test-bad/runner.js
@@ -26,13 +26,11 @@ not ok 1 - /interpreted/test/test-bad/runner.js # time=39.195ms
         
         1..1
         # failed 1 test
-    not ok 1 - test stringify interpreted # time=29.098ms
+    not ok 1 - test stringify interpreted
     
     1..1
     # failed 1 test
-    # time=39.195ms
 }
 
 1..1
 # failed 1 test
-# time=559.272ms

--- a/test/fixture/update-file.txt
+++ b/test/fixture/update-file.txt
@@ -1,12 +1,10 @@
 TAP version 13
-ok 1 - /interpreted/test/update-file/runner.js # time=24.844ms {
+ok 1 - /interpreted/test/update-file/runner.js {
     # Subtest: test stringify interpreted
         1..0
-    ok 1 - test stringify interpreted # time=12.867ms
+    ok 1 - test stringify interpreted
     
     1..1
-    # time=24.844ms
 }
 
 1..1
-# time=578.289ms

--- a/test/runner.js
+++ b/test/runner.js
@@ -35,6 +35,9 @@ function runTest(name, callback) {
       actual = replaceAll(actual.toString(), process.execPath, '/node');
       actual = actual.replace(/exit:(\s+)8/, "exit:$11");
 
+      // Remove timings
+      actual = actual.replace(/([^\s]) # time=\d+(\.\d+)?m?s/g, '$1'); // `time=` at the end of a line
+      actual = actual.replace(/\n\s*# time=\d+(\.\d+)?m?s/g, ''); // `time=` as the only element in this line
 
       fs.writeFile(path.resolve(__dirname, 'fixture', name + '.txt'), actual, function (err, expected) {
         //t.deepEqual(actual.toString(), expected.toString());


### PR DESCRIPTION
I find it hard to run `npm test` on *interpreted* because it changes the files in `test/fixture`, as the TAP output contains the duration in form of `# time=...`. Because the files in `test/fixture` are checked into the Git repo, this always results in untracked changes.

In this PR I simply remove all the `# time=...` comments in the written TAP output and re-run the tests to the remove these comments in the files in `test/fixture`. I found no flag to tell TAP to not print the durations at first, so working on the produced string (as already done for changing file paths, etc.) seems easier for me than to create a new TAP reporter.