### PR TITLE
Use latest node.js and LTS versions in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4"
+  - node
+  - 'lts/*'
 sudo: false
-
-


### PR DESCRIPTION
The newest TAP uses JS features only added in recent node.js versions. It makes sense to (only) support the latest node.js and LTS versions (see [Travis CI documentation](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions)), so I updated `.travis.yml` accordingly.